### PR TITLE
feat: support getting slice element by index

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -142,6 +142,16 @@ func (s Slice) Get(path string) Value {
 		return newSlice
 	}
 
+	indexString, remainingPath, _ := strings.Cut(path, ".")
+	index, err := strconv.Atoi(indexString)
+	if err == nil && index >= 0 && index < len(s) {
+		result := s[index]
+		if remainingPath != "" {
+			return result.Get(remainingPath)
+		}
+		return result
+	}
+
 	// path is not supported on a slice
 	return undefinedScalar
 }

--- a/value_test.go
+++ b/value_test.go
@@ -77,6 +77,18 @@ func TestGet(t *testing.T) {
 		require.Equal(t, &scalar{v: "a"}, value.Get(`array.#(="a")`))
 	})
 
+	t.Run("should get array values using indices", func(t *testing.T) {
+		require.Equal(t, "a", value.Get("array.0").String())
+		require.Equal(t, "b", value.Get("array.1").String())
+		require.False(t, value.Get("array.2").Exists())
+		require.Equal(t, "", value.Get("array.2").String())
+		require.False(t, value.Get("array.-1").Exists())
+		require.False(t, value.Get("array.zzzz").Exists()) // not supported by slice
+		require.Equal(t, "Alice", value.Get("nestedArray.0.name").String())
+		require.Equal(t, "Bob", value.Get("nestedArray.1.name").String())
+		require.False(t, value.Get("nestedArray.2.name").Exists())
+	})
+
 	t.Run("should support nested get calls", func(t *testing.T) {
 		require.Equal(t, "John", value.Get("nestedObject").Get("name").String())
 		require.Equal(t, "Alice", value.Get("nestedArray").Get("#(name=Alice)").Get("name").String())


### PR DESCRIPTION
Support getting slice elements by index, for example:

```go
v.Get("instruments.0.name")
```